### PR TITLE
WINDUPRULE-989 Redis Cache config rule message change

### DIFF
--- a/rules/rules-reviewed/azure/springboot/spring-boot-to-azure-cache.windup.xml
+++ b/rules/rules-reviewed/azure/springboot/spring-boot-to-azure-cache.windup.xml
@@ -63,7 +63,7 @@
                 <hint title="Redis Cache connection string found" category-id="information" effort="0">
                     <message>
                         <![CDATA[
-                        The application uses a Redis Cache connection string, username, or password.
+                        Redis Cache connection string, username, or password used in this application.
 
                         Checkout Azure Cache for Redis for a fully managed cache on Azure.
                         ]]>

--- a/rules/rules-reviewed/azure/springboot/tests/spring-boot-to-azure-cache.windup.test.xml
+++ b/rules/rules-reviewed/azure/springboot/tests/spring-boot-to-azure-cache.windup.test.xml
@@ -21,7 +21,7 @@
                 <when>
                     <not>
                         <iterable-filter size="4">
-                            <hint-exists message="The application uses a Redis Cache connection string, username, or password." />
+                            <hint-exists message="Redis Cache connection string, username, or password used in this application" />
                         </iterable-filter>
                     </not>
                 </when>


### PR DESCRIPTION
Hi @KaiqianYang 
The changes that you made were perfectly valid. 
However one of the integration tests was failing. As I understand it the first rule test was treating the messages generated by the second rule as matching. It appears the full stop character at the end of the message for the first rule was being ignored. 
In the interests of expediency I have reworded the message on the new rule to avoid that 'collision'.
If you are happy with my proposed changes, please merge my changes into your PR and I'll merge your PR to master.
Thanks,
Phil 