### PR TITLE
JKS Rule message rewording

### DIFF
--- a/rules/rules-reviewed/azure/springboot/spring-boot-to-azure-jks.windup.xml
+++ b/rules/rules-reviewed/azure/springboot/spring-boot-to-azure-jks.windup.xml
@@ -23,8 +23,8 @@
                 <file filename="{*}.jks"/>
             </when>
             <perform>
-                <hint title="JKS file" effort="2" category-id="mandatory">
-                    <message>JKS(Java KeyStore) file is found. Make sure to externalize jks store</message>
+                <hint title="JKS file" effort="1" category-id="mandatory">
+                    <message>Java KeyStore file is found. Make sure to externalize the Java Keystore.</message>
                     <tag>JKS</tag>
                 </hint>
             </perform>

--- a/rules/rules-reviewed/azure/springboot/tests/spring-boot-to-azure-jks.windup.test.xml
+++ b/rules/rules-reviewed/azure/springboot/tests/spring-boot-to-azure-jks.windup.test.xml
@@ -9,12 +9,12 @@
                 <when>
                     <not>
                         <iterable-filter size="1">
-                            <hint-exists message="JKS(Java KeyStore) file is found. Make sure to externalize jks store" />
+                            <hint-exists message="Java KeyStore file is found." />
                         </iterable-filter>
                     </not>
                 </when>
                 <perform>
-                    <fail message="jks file hint was not found!" />
+                    <fail message="spring-boot-to-azure-jks-test-01000 failed!" />
                 </perform>
             </rule>
         </rules>


### PR DESCRIPTION
Hi @KaiqianYang 
I think the reason for the test failure was something tot do with the ( character in the message.
I have reworded the message, changed the effort to 1 SP (as we have these guidelines for SP values https://access.redhat.com/documentation/en-us/migration_toolkit_for_runtimes/1.0/html/cli_guide/reference_material#how_story_points_are_estimated_in_rules)
I have also updated the test failure message to make it easier to track the failing rule.
If you are happy with my changes then merge my PR into yours and I will merge yours to master. 