### PR TITLE
updates to the apm technology discover rules

### DIFF
--- a/rules/rules-reviewed/technology-usage/apm-technology-usage.windup.xml
+++ b/rules/rules-reviewed/technology-usage/apm-technology-usage.windup.xml
@@ -21,7 +21,7 @@
             <perform>
                 <technology-identified name="Application Insights">
                     <tag name="Sustain"/>
-                    <tag name="Monitoring"/>
+                    <tag name="Observability"/>
                     <tag name="Embedded"/>
                 </technology-identified>
             </perform>
@@ -35,7 +35,7 @@
             <perform>
                 <technology-identified name="New Relic">
                     <tag name="Sustain"/>
-                    <tag name="Monitoring"/>
+                    <tag name="Observability"/>
                     <tag name="Embedded"/>
                 </technology-identified>
             </perform>
@@ -49,7 +49,7 @@
             <perform>
                 <technology-identified name="Elastic APM">
                     <tag name="Sustain"/>
-                    <tag name="Monitoring"/>
+                    <tag name="Observability"/>
                     <tag name="Embedded"/>
                 </technology-identified>
             </perform>
@@ -63,7 +63,7 @@
             <perform>
                 <technology-identified name="Dynatrace">
                     <tag name="Sustain"/>
-                    <tag name="Monitoring"/>
+                    <tag name="Observability"/>
                     <tag name="Embedded"/>
                 </technology-identified>
             </perform>

--- a/rules/rules-reviewed/technology-usage/tests/apm-technology-usage.windup.test.xml
+++ b/rules/rules-reviewed/technology-usage/tests/apm-technology-usage.windup.test.xml
@@ -15,7 +15,7 @@
                     <not>
                         <technology-statistics-exists name="Application Insights" number-found="1">
                             <tag name="Sustain"/>
-                            <tag name="Monitoring"/>
+                            <tag name="Observability"/>
                             <tag name="Embedded"/>
                         </technology-statistics-exists>
                     </not>
@@ -29,7 +29,7 @@
                     <not>
                         <technology-statistics-exists name="New Relic" number-found="1">
                             <tag name="Sustain"/>
-                            <tag name="Monitoring"/>
+                            <tag name="Observability"/>
                             <tag name="Embedded"/>
                         </technology-statistics-exists>
                     </not>
@@ -43,7 +43,7 @@
                     <not>
                         <technology-statistics-exists name="Elastic APM" number-found="1">
                             <tag name="Sustain"/>
-                            <tag name="Monitoring"/>
+                            <tag name="Observability"/>
                             <tag name="Embedded"/>
                         </technology-statistics-exists>
                     </not>
@@ -57,7 +57,7 @@
                     <not>
                         <technology-statistics-exists name="Dynatrace" number-found="1">
                             <tag name="Sustain"/>
-                            <tag name="Monitoring"/>
+                            <tag name="Observability"/>
                             <tag name="Embedded"/>
                         </technology-statistics-exists>
                     </not>

--- a/rules/rules-reviewed/technology-usage/tests/apm.windup.test.xml
+++ b/rules/rules-reviewed/technology-usage/tests/apm.windup.test.xml
@@ -11,7 +11,7 @@
             <rule id="apm-test-00000">
                 <when>
                     <not>
-                        <classification-exists classification="Application Performance Management (APM) tool - Application Insights" />
+                        <classification-exists classification="Application Performance Management \(APM\) tool - Application Insights" />
                     </not>
                 </when>
                 <perform>
@@ -21,7 +21,7 @@
             <rule id="apm-test-00001">
                 <when>
                     <not>
-                        <classification-exists classification="Application Performance Management (APM) tool - New Relic" />
+                        <classification-exists classification="Application Performance Management \(APM\) tool - New Relic" />
                     </not>
                 </when>
                 <perform>
@@ -31,7 +31,7 @@
             <rule id="apm-test-00002">
                 <when>
                     <not>
-                        <classification-exists classification="Application Performance Management (APM) tool - Elastic APM" />
+                        <classification-exists classification="Application Performance Management \(APM\) tool - Elastic APM" />
                     </not>
                 </when>
                 <perform>
@@ -41,7 +41,7 @@
             <rule id="apm-test-00003">
                 <when>
                     <not>
-                        <classification-exists classification="Application Performance Management (APM) tool - Dynatrace" />
+                        <classification-exists classification="Application Performance Management \(APM\) tool - Dynatrace" />
                     </not>
                 </when>
                 <perform>


### PR DESCRIPTION
@KaiqianYang There were two problems with the APM Rules
1. The Tests for apm.windup.test.xml had to have the bracket characters escaped
2. The technology tags were getting assigned to Monitoring, I have changed that to Observability.
3. Hopefully if you merge my PR to yours and the automated tests will pass, then Mark Brophy will be able to merge it to master.